### PR TITLE
Add basic auth to WebSocket connection

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"net/http"
 
 	"github.com/pkg/errors"
 
@@ -19,7 +20,7 @@ var (
 
 var _ Client = (*client)(nil)
 
-func NewClient(ctx context.Context, rawURL string) (Client, error) {
+func NewClient(ctx context.Context, rawURL string, requestHeader http.Header) (Client, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse url")
@@ -31,7 +32,7 @@ func NewClient(ctx context.Context, rawURL string) (Client, error) {
 	case "http", "https":
 		transport, err = newHTTPTransport(ctx, parsedURL)
 	case "wss", "ws":
-		transport, err = newWebsocketTransport(ctx, parsedURL)
+		transport, err = newWebsocketTransport(ctx, parsedURL, requestHeader)
 	default:
 		transport, err = newIPCTransport(ctx, parsedURL)
 	}

--- a/node/websocket.go
+++ b/node/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/url"
+	"net/http"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -15,8 +16,10 @@ type websocketTransport struct {
 
 // newWebsocketTransport creates a Connection to the passed in URL.  Use the supplied Context to shutdown the connection by
 // cancelling or otherwise aborting the context.
-func newWebsocketTransport(ctx context.Context, addr *url.URL) (transport, error) {
-	wsConn, _, err := websocket.DefaultDialer.DialContext(ctx, addr.String(), nil)
+func newWebsocketTransport(ctx context.Context, addr *url.URL, requestHeader http.Header) (transport, error) {
+    // if getEnv INFURA_API_KEY && INFURA_PROJECT_ID then create Authorization header base64(INFURA_PROJECT_ID:INFURA_API_KEY)
+
+	wsConn, _, err := websocket.DefaultDialer.DialContext(ctx, addr.String(), requestHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/node/websocket.go
+++ b/node/websocket.go
@@ -17,8 +17,6 @@ type websocketTransport struct {
 // newWebsocketTransport creates a Connection to the passed in URL.  Use the supplied Context to shutdown the connection by
 // cancelling or otherwise aborting the context.
 func newWebsocketTransport(ctx context.Context, addr *url.URL, requestHeader http.Header) (transport, error) {
-    // if getEnv INFURA_API_KEY && INFURA_PROJECT_ID then create Authorization header base64(INFURA_PROJECT_ID:INFURA_API_KEY)
-
 	wsConn, _, err := websocket.DefaultDialer.DialContext(ctx, addr.String(), requestHeader)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Adds support for Authorization headers on the WebSocket connection and requests.

Environment variables needed for running `node/rpc_test.go`:
- `ETHLIBS_TEST_WS_URL`: base ws URL for example wss://goerli.infura.io/ws/v3/
- `AUTH_ID`: project id 
- `AUTH_PASS`: project API key
