### PR TITLE
Accept devnet/localhost node URLs

### DIFF
--- a/.github/workflows/rpc-test.yaml
+++ b/.github/workflows/rpc-test.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ETHLIBS_TEST_URL: https://goerli.infura.io/v3/
+  NODE_URL: ${{ secrets.NODE_URL }}
   AUTH_ID: ${{ secrets.INFURA_PROJECT_ID }}
   AUTH_PASS: ${{ secrets.INFURA_API_KEY }}
 

--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -16,40 +16,41 @@ import (
 
 func getClient(t *testing.T, ctx context.Context) node.Client {
 
-    // Save base URL. Fail if not set.
+	// Save base URL. Fail if not set.
+	// NODE_URL must end with trailing '/' i.e http://url:port/
 	base_url := os.Getenv("NODE_URL")
 	if base_url == "" {
 		t.Skip("NODE_URL not set, skipping test.")
 	}
 
-    // If AUTH_ID is not set, return connection without Basic Auth header
+	// If AUTH_ID is not set, return connection without Basic Auth header
 	auth_id := os.Getenv("AUTH_ID")
-    if auth_id == "" {
-        conn, err := node.NewClient(ctx, base_url, http.Header{})
-        require.NoError(t, err, "creating websocket connection should not fail")
-        return conn
-    }
+	if auth_id == "" {
+		conn, err := node.NewClient(ctx, base_url, http.Header{})
+		require.NoError(t, err, "creating websocket connection should not fail")
+		return conn
+	}
 
-    // If AUTH_ID is present then check AUTH_PASS and create Basic Auth http header
-    // This is ment for INFURA test nodes to work in a secure way
-    auth_pass := os.Getenv("AUTH_PASS")
-    if auth_pass == "" {
-        t.Skip("AUTH_PASS not set, skipping test.")
-    }
+	// If AUTH_ID is present then check AUTH_PASS and create Basic Auth http header
+	// This is ment for INFURA test nodes to work in a secure way
+	auth_pass := os.Getenv("AUTH_PASS")
+	if auth_pass == "" {
+		t.Skip("AUTH_PASS not set, skipping test.")
+	}
 
-    // format URL -> base_url/auth_id
-    url := fmt.Sprintf("%s%s", base_url, auth_id)
+	// format URL -> base_url/auth_id
+	url := fmt.Sprintf("%s%s", base_url, auth_id)
 
-    // Create Basic Auth token base64(id:pass) for http header
-    base64Header := ob64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", auth_id, auth_pass)))
-    header := http.Header{
-        "Authorization": {fmt.Sprintf("Basic %s", base64Header)},
-    }
+	// Create Basic Auth token base64(id:pass) for http header
+	base64Header := ob64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", auth_id, auth_pass)))
+	header := http.Header{
+		"Authorization": {fmt.Sprintf("Basic %s", base64Header)},
+	}
 
-    // Create connection
-    conn, err := node.NewClient(ctx, url, header)
-    require.NoError(t, err, "creating websocket connection should not fail")
-    return conn
+	// Create connection
+	conn, err := node.NewClient(ctx, url, header)
+	require.NoError(t, err, "creating websocket connection should not fail")
+	return conn
 }
 
 func TestConnection_Call_Simple_Contract(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- IMPORTANT: NODE_URL secret is mandatory and must include a trailing '/' i.e `http://localhost:port/`
- Tests can point to http://localhost:port URL skipping Basic Auth header if not required. 
- Ability to set the target URL to a public or local endpoint not implementing Basic Auth. This is the case of `devnet` public endpoint ATM. 

#### To fix:

- [ ] TestConnection_Call_Simple_Contract
- [x] TestConnection_Get_Accounts
- [x] TestConnection_Get_Balance
- [ ] TestConnection_GetTransactionCount
- [x] TestConnection_EstimateGas
- [ ] TestConnection_MaxPriorityFeePerGas
- [x] TestConnection_GasPrice
- [x] TestConnection_NetVersion
- [x] TestConnection_ChainId
- [x] TestConnection_SendRawTransactionInValidEmpty
- [ ] TestConnection_SendRawTransactionInValidOldNonce
- [ ] TestConnection_FutureBlockByNumber
- [ ] TestConnection_InvalidBlockByHash
- [ ] TestConnection_InvalidTransactionByHash